### PR TITLE
#19 Show reference names if possible

### DIFF
--- a/src/components/overview/properties/types/types.component.html
+++ b/src/components/overview/properties/types/types.component.html
@@ -9,7 +9,7 @@
     <ng-container *ngFor="let type of types.types">
       <div [ngSwitch]="type.type">
         <code *ngSwitchCase="'stringLiteral'" class="type string">"{{ type.value }}"</code>
-        <code *ngSwitchCase="'reference'" class="type reference">{{ type.type }}</code>
+        <code *ngSwitchCase="'reference'" class="type reference">{{ type.name || type.type }}</code>
         <code *ngSwitchDefault class="type">{{ type.value || type.name }}</code>,
       </div>
     </ng-container>

--- a/test/addon-examples/button/button.component.ts
+++ b/test/addon-examples/button/button.component.ts
@@ -48,7 +48,7 @@ export class ButtonComponent<T> {
    * @required
    */
   @Input()
-  public label: string;
+  public label: string | Date;
 
   /** Size of the button. */
   @Input()


### PR DESCRIPTION
Have done some super basic testing on this, seems to hold up.

Shows the name of the reference in the `One of <` block.

Used a pretty arbitrary place to demonstrate the functionality, but tbh I am not sure when I would union different types to the same member.